### PR TITLE
add break-inside: avoid; to .location-item for firefox rendering. ty …

### DIFF
--- a/app/assets/stylesheets/hours.scss
+++ b/app/assets/stylesheets/hours.scss
@@ -15,6 +15,7 @@ li{
 	.location-item {
 		padding:.61em;
 		-webkit-column-break-inside: avoid;
+		break-inside: avoid;
 		&:nth-child(even) {
 			background-color: $color_3;
 		}


### PR DESCRIPTION
add break-inside: avoid; to .location-item for firefox rendering. ty @etm2129. Closes HOURS-102