### PR TITLE
HOURS-124

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7.5', '3.0.3']
+        ruby-version: ['3.0.3']
         node: ['8', '12']
     env:
       RAILS_ENV: test

--- a/Gemfile
+++ b/Gemfile
@@ -40,10 +40,10 @@ group :development, :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '~> 3.33'
   # For testing with chromedriver
-  gem 'selenium-webdriver', '~> 3.142'
+  gem 'selenium-webdriver', '~> 4.0'
   gem 'rexml', '~> 3.2', '>= 3.2.4'
   # For automatically updating chromedriver
-  gem 'webdrivers', '~> 4.0', require: false
+  gem 'webdrivers', '~> 5.3.0', require: false
   gem 'rspec-rails', '~> 4.0'
   gem 'factory_bot_rails', ' ~> 4.0'
   gem 'simplecov',      require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,7 +108,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
-    childprocess (3.0.0)
     coderay (1.1.2)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
@@ -252,7 +251,7 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.11.0)
-    rubyzip (2.3.0)
+    rubyzip (2.3.2)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -264,9 +263,10 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    selenium-webdriver (3.142.7)
-      childprocess (>= 0.5, < 4.0)
-      rubyzip (>= 1.2.2)
+    selenium-webdriver (4.9.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -303,10 +303,11 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (4.6.0)
+    webdrivers (5.3.1)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
-      selenium-webdriver (>= 3.0, < 4.0)
+      selenium-webdriver (~> 4.0, < 4.11)
+    websocket (1.2.10)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -346,7 +347,7 @@ DEPENDENCIES
   rspec-rails (~> 4.0)
   sass (~> 3.7.4)
   sass-rails (~> 5)
-  selenium-webdriver (~> 3.142)
+  selenium-webdriver (~> 4.0)
   simplecov
   simplecov-lcov
   spring
@@ -356,7 +357,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
-  webdrivers (~> 4.0)
+  webdrivers (~> 5.3.0)
 
 BUNDLED WITH
-   2.3.9
+   2.3.13

--- a/app/views/layouts/_fat_footer.html.erb
+++ b/app/views/layouts/_fat_footer.html.erb
@@ -46,7 +46,7 @@
         <ul class="list-unstyled">
             <li><a href="https://library.columbia.edu/about/policies/gifts-policy.html" class="text-white">Donate Books or Items</a></li>
             <li><a rel="noopener" href="https://feedback.cul.columbia.edu/feedback_submission/lweb" class="text-white" target="_blank">Suggestions &amp; Feedback</a></li>
-            <li><a href="https://library.columbia.edu/resolve/lweb0006" class="text-white">Report an E-Resource Problem</a></li>
+            <li><a href="https://resolver.library.columbia.edu/lweb0006" class="text-white">Report an E-Resource Problem</a></li>
             <li><a href="https://library.columbia.edu/about/awards/bancroft.html" class="text-white">The Bancroft Prizes</a></li>
             <li><a href="https://library.columbia.edu/about/student_advisory_committee.html" class="text-white">Student Library Advisory Committee</a></li>
             <li><a href="https://library.columbia.edu/about/jobs-internships.html" class="text-white">Jobs &amp; Internships</a></li>

--- a/app/views/layouts/_topnavbar.html.erb
+++ b/app/views/layouts/_topnavbar.html.erb
@@ -22,7 +22,7 @@
 					 <nav id="global-menu" class="d-flex justify-content-sm-end">
 						 <ul class="navbar-nav">
 							 <li class="nav-item">
-								 <a class="nav-link" href="https://library.columbia.edu/resolve/lweb0087">My Library Account</a>
+								 <a class="nav-link" href="https://resolver.library.columbia.edu/lweb0087">My Library Account</a>
 							 </li>
 							 <li class="nav-item">
 								 <a class="nav-link" href="https://hours.library.columbia.edu/">Hours</a>
@@ -129,14 +129,14 @@
 														 <div class="row">
 																 <div class="col">
 																		 <div class="cul-cols">
-																				 <a class="dropdown-item text-white bg-secondary" href="https://library.columbia.edu/resolve/clio">CLIO: Columbia Libraries Catalog</a>
+																				 <a class="dropdown-item text-white bg-secondary" href="https://resolver.library.columbia.edu/clio">CLIO: Columbia Libraries Catalog</a>
 																				 <a class="dropdown-item text-white bg-secondary" href="https://library.columbia.edu/collections.html">About Our Collections</a>
 																				 <a class="dropdown-item text-white bg-secondary" href="https://library.columbia.edu/collections/digital-collections.html">Digital Collections &amp; Exhibitions</a>
 																				 <a class="dropdown-item text-white bg-secondary" href="https://library.columbia.edu/collections/archives-portal.html">Archival Collections</a>
 																				 <a class="dropdown-item text-white bg-secondary" href="https://library.columbia.edu/collections/oral-history-portal.html">Oral History Collections</a>
 																				 <a class="dropdown-item text-white bg-secondary" href="https://academiccommons.columbia.edu/">Academic Commons</a>
 																				 <a class="dropdown-item text-white bg-secondary" href="https://library.columbia.edu/collections/eresources.html">E-Resources</a>
-																				 <a class="dropdown-item text-white bg-secondary" href="http://www.columbia.edu/cgi-bin/cul/resolve?lweb0004">Recommend a Title for Purchase</a>
+																				 <a class="dropdown-item text-white bg-secondary" href="https://resolver.library.columbia.edu/lweb0004">Recommend a Title for Purchase</a>
 																				 <a class="dropdown-item text-white bg-secondary" href="https://library.columbia.edu/about/staff/subject-specialists-by-subject.html">Subject Specialists</a>
 																		 </div>
 																 </div>


### PR DESCRIPTION
HOURS-124: Update resolver urls to use new format

Plus:
- Remove Ruby 2.7.5 from CI because we don't run the hours app on that version anymore
- Update selenium-webdriver and webdrivers gems