### PR TITLE
Add Matomo analytics code and remove secondary GA id

### DIFF
--- a/app/views/layouts/public.html.erb
+++ b/app/views/layouts/public.html.erb
@@ -24,8 +24,22 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
       gtag('config', '<%= Rails.application.secrets[:analytics_key]%>');
-      gtag('config', 'G-QRM52K5M78');
     </script>
+    <!-- Matomo -->
+    <script>
+      var _paq = window._paq = window._paq || [];
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+        var u="https://columbia-libraries.matomo.cloud/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '18']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src='https://cdn.matomo.cloud/columbia-libraries.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <!-- End Matomo Code -->
     <% end -%>
     <script src="https://cdn.cul.columbia.edu/fontawesome/pro/v5.x/js/all.js" defer="defer" crossorigin="anonymous"></script>
   </head>


### PR DESCRIPTION
We'll want to update secrets.yml with the newer GA4 tracking id right before we deploy this change to prod.

It's not actually a secret value, but that's where the app currently looks for the id, so I figured I'd be consistent with the current practice.